### PR TITLE
Eval-  precision recall metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ gdrive-keyfile.json
 .vscode
 log_db.json
 config.yaml
+eval_logs/

--- a/README.md
+++ b/README.md
@@ -197,11 +197,15 @@ python eval.py --eval-csv <test_data.csv> --n-neighbors 3 --threshold 0.5 --cert
 
 This `test_data.csv` should be a two column comma separated file with the headings: `text, label`. An example of such a file can be found [here](https://gist.githubusercontent.com/cvqluu/df0323b68f17bc255d546d4c6865e9fd/raw/a5f601d7a23101afd6f97c23a0798b227921d20c/antiveg_comments.csv).
 
-The output of this script will provide the following outputs, which are a mix of metrics, figures, and other useful information:
+This script will provide the following outputs in a unique `eval_logs/<eval_run_id>/` folder:
 
-- Balanced accuracy
-- (TODO) Per-class recall/precision
-- (TODO) Confusion matrix
-- (TODO) Separated lists of examples
-  - Misclassified examples (with incorrect class and incorrect neighbor matched)
-  - Correctly classified examples
+- Results summary: `results.csv`
+  - Balanced accuracy
+  - Averaged Precision and Recall
+    - `"micro", "macro", "weighted"`: See [sklearn-docs](https://scikit-learn.org/stable/modules/generated/sklearn.metrics.precision_recall_fscore_support.html#sklearn.metrics.precision_recall_fscore_support)
+- Confusion matrices:
+  - `cm_true.png`: Normalized by true label (diagonal is per-class precision)
+  - `cm_pred.png`: Normalized by pred label (diagonal is per-class recall)
+  - `cm_none.png`: Un-normalized
+- Every example evaluated: `raw_results.csv`:
+  - Contains predicted label, true label

--- a/argmatcher.py
+++ b/argmatcher.py
@@ -417,7 +417,6 @@ class ArgMatcher:
         weighted_vote = np.argmax(np.sum(weighted_vote, axis=1), -1)
 
         # Get the top 1 prediction
-        neigh_eye = np.eye(N_neighbors)
         top1 = y[neigh_ind[:, 0]]
 
         # Get indexes of examples which meet certainty thresh

--- a/argmatcher.py
+++ b/argmatcher.py
@@ -63,9 +63,12 @@ class ArgMatcher:
             self.arg_dict = pickle.load(open(arg_dict_path, "rb"))
             self.template_dict = pickle.load(open(template_dict_path, "rb"))
 
+        # Mapping of encoded label to text
+        # E.g. {plants_feel_pain: 4}
         self.key_label_map = OrderedDict(
             {v: k for k, v in enumerate(self.arg_dict["key"])}
         )
+        # E.g. {4: plants_feel_pain}
         self.label_key_map = OrderedDict({v: k for k, v in self.key_label_map.items()})
 
         self.eye = np.eye(len(self.arg_dict["argument"]) + 1)

--- a/eval.py
+++ b/eval.py
@@ -14,6 +14,7 @@ from sklearn.metrics import (
     balanced_accuracy_score,
     confusion_matrix,
     ConfusionMatrixDisplay,
+    precision_recall_fscore_support,
 )
 
 
@@ -97,6 +98,7 @@ def _filter_data(df, argm):
 
     new_len = len(reduced_df)
 
+    print(f"Training set size is {len(train_texts)}")
     print(f"Reduced dataframe from {original_len} -> {new_len}")
     assert new_len != 0, "After filtering out bad rows, dataframe had 0 rows"
 
@@ -136,8 +138,7 @@ def evaluate_model(
     lookup = lambda x: argm.key_label_map[x]
     true_labels_enc = np.array(list(map(lookup, labels)))
 
-    bal_acc = balanced_accuracy_score(true_labels_enc, pred_labels_enc)
-    return bal_acc, pred_labels_enc, true_labels_enc
+    return pred_labels_enc, true_labels_enc
 
 
 def log_eval_results(log_folder, argm, texts, pred_labels_enc, true_labels_enc):
@@ -158,7 +159,22 @@ def log_eval_results(log_folder, argm, texts, pred_labels_enc, true_labels_enc):
     raw_results_df.to_csv(os.path.join(log_folder, "raw_results.csv"), index=False)
 
     ## Make small results output with single value metrics
-    # TODO
+    results_df = pd.DataFrame()
+    bal_acc = balanced_accuracy_score(true_labels_enc, pred_labels_enc)
+    results_df["Balanced Accuracy"] = [bal_acc]
+
+    for avg_method in ["micro", "macro", "weighted"]:
+        precision, recall, _, _ = precision_recall_fscore_support(
+            true_labels_enc, pred_labels_enc, average=avg_method, zero_division=0
+        )
+        results_df[f"Precision ({avg_method})"] = precision
+        results_df[f"Recall ({avg_method})"] = recall
+
+    results_df = results_df.T
+    results_df.to_csv(os.path.join(log_folder, "results.csv"), header=False)
+    print("\n")
+    print(results_df)
+    print("\n")
 
     ## Plot confusion matrices
     # Get label ordering, removing missing args
@@ -166,9 +182,10 @@ def log_eval_results(log_folder, argm, texts, pred_labels_enc, true_labels_enc):
     label_ordering = [l for l in label_ordering if l in set(true_labels_enc)]
     display_labels = [arglookup(l) for l in label_ordering]
 
-    make_confusion_matrices(
+    cm_pred, cm_true, cm_none = make_confusion_matrices(
         true_labels_enc, pred_labels_enc, label_ordering, display_labels, log_folder
     )
+    print(f"Results output to {log_folder}")
 
 
 def make_confusion_matrices(y_true, y_pred, label_ordering, display_labels, outfolder):
@@ -186,6 +203,8 @@ def make_confusion_matrices(y_true, y_pred, label_ordering, display_labels, outf
         disp.plot(ax=ax, xticks_rotation="vertical", colorbar=True)
         plt.tight_layout()
         fig.savefig(os.path.join(outfolder, f"cm_{k}.png"), transparent=False)
+
+    return cm_pred, cm_true, cm_none
 
 
 if __name__ == "__main__":
@@ -207,7 +226,7 @@ if __name__ == "__main__":
         certain_threshold: {args.certain_threshold}"
     )
 
-    bal_acc, pred_labels_enc, true_labels_enc = evaluate_model(
+    pred_labels_enc, true_labels_enc = evaluate_model(
         argm,
         texts,
         labels,
@@ -215,12 +234,11 @@ if __name__ == "__main__":
         threshold=args.threshold,
         certain_threshold=args.certain_threshold,
     )
-    print(f"Balanced accuracy is: {bal_acc}")
 
     os.makedirs("./eval_logs/", exist_ok=True)
 
     ename = os.path.splitext(os.path.basename(eval_data))[0]
-    ctime = datetime.now().strftime("%H-%M-%d-%m-%Y")
+    ctime = datetime.now().strftime("%d-%m-%Y-%H-%M")
     log_folder = os.path.join("./eval_logs/", f"{ename}_{ctime}")
     os.makedirs(log_folder, exist_ok=True)
 

--- a/eval.py
+++ b/eval.py
@@ -2,13 +2,19 @@ import argparse
 from functools import reduce
 import os
 import spacy
+from datetime import datetime
 
 import pandas as pd
 import numpy as np
 
 from argmatcher import ArgMatcher
+import matplotlib.pyplot as plt
 
-from sklearn.metrics import balanced_accuracy_score
+from sklearn.metrics import (
+    balanced_accuracy_score,
+    confusion_matrix,
+    ConfusionMatrixDisplay,
+)
 
 
 def parse_args():
@@ -64,19 +70,35 @@ def _verify_data(df):
 
 def _filter_data(df, argm):
     """
-    Filters out empty text rows, along with
-    labels which doesn't match existing arguments
+    Filters out data, removing:
+        - empty text
+        - labels which don't match arguments
+        - text which is already in the training set
+
+    Inputs:
+        df: pd.DataFrame that contains label, text columns
+        argm: ArgMatcher object
+
+    Returns:
+        reduced_df: pd.DataFrame with filtered out rows
     """
     known_args = set(list(argm.key_label_map.keys()))
     original_len = len(df)
 
+    # Remove if label not recognized
     reduced_df = df[df.label.isin(known_args)]
+
+    # Remove empty text field
     reduced_df = reduced_df[reduced_df.text.notnull()]
+
+    # Remove examples in training set
+    train_texts = argm.template_dict["text"]
+    reduced_df = reduced_df[~reduced_df.text.isin(train_texts)]
 
     new_len = len(reduced_df)
 
     print(f"Reduced dataframe from {original_len} -> {new_len}")
-    assert new_len != 0, "After filtering out illegal rows, dataframe had 0 rows"
+    assert new_len != 0, "After filtering out bad rows, dataframe had 0 rows"
 
     new_num_labels_seen = len(set(reduced_df.label.values))
     num_known_args = len(known_args)
@@ -103,7 +125,7 @@ def evaluate_model(
     """
     Evaluate the classification performance of the argmatcher
     """
-    pred_labels = argm.match_batch_text(
+    pred_labels_enc = argm.match_batch_text(
         texts,
         N_neighbors=n_neighbors,
         threshold=threshold,
@@ -112,17 +134,58 @@ def evaluate_model(
 
     # Need to encode labels
     lookup = lambda x: argm.key_label_map[x]
-    encoded_labels = np.array(list(map(lookup, labels)))
+    true_labels_enc = np.array(list(map(lookup, labels)))
 
-    bal_acc = balanced_accuracy_score(encoded_labels, pred_labels)
-    return bal_acc, pred_labels, encoded_labels
+    bal_acc = balanced_accuracy_score(true_labels_enc, pred_labels_enc)
+    return bal_acc, pred_labels_enc, true_labels_enc
 
 
-def log_eval_results(log_folder, argm, bal_acc, pred_labels, encoded_labels):
+def log_eval_results(log_folder, argm, texts, pred_labels_enc, true_labels_enc):
     """
     Log evaluation results in some folder for further inspection
     """
-    raise NotImplementedError
+    ## Write the pred_labels and true_labels
+    arglookup = lambda x: argm.label_key_map[x]
+
+    raw_results_df = pd.DataFrame(
+        columns=["text", "true_label_enc", "pred_label_enc", "true_label", "pred_label"]
+    )
+    raw_results_df["text"] = texts
+    raw_results_df["true_label_enc"] = true_labels_enc
+    raw_results_df["pred_label_enc"] = pred_labels_enc
+    raw_results_df["true_label"] = list(map(arglookup, true_labels_enc))
+    raw_results_df["pred_label"] = list(map(arglookup, pred_labels_enc))
+    raw_results_df.to_csv(os.path.join(log_folder, "raw_results.csv"), index=False)
+
+    ## Make small results output with single value metrics
+    # TODO
+
+    ## Plot confusion matrices
+    # Get label ordering, removing missing args
+    label_ordering = list(argm.label_key_map.keys())
+    label_ordering = [l for l in label_ordering if l in set(true_labels_enc)]
+    display_labels = [arglookup(l) for l in label_ordering]
+
+    make_confusion_matrices(
+        true_labels_enc, pred_labels_enc, label_ordering, display_labels, log_folder
+    )
+
+
+def make_confusion_matrices(y_true, y_pred, label_ordering, display_labels, outfolder):
+    """
+    Make confusion matrix plots
+    """
+    cm_pred = confusion_matrix(y_true, y_pred, labels=label_ordering, normalize="pred")
+    cm_true = confusion_matrix(y_true, y_pred, labels=label_ordering, normalize="true")
+    cm_none = confusion_matrix(y_true, y_pred, labels=label_ordering, normalize=None)
+
+    cm_dict = {"true": cm_true, "pred": cm_pred, "none": cm_none}
+    for k, v in cm_dict.items():
+        disp = ConfusionMatrixDisplay(confusion_matrix=v, display_labels=display_labels)
+        fig, ax = plt.subplots(1, figsize=(20, 20))
+        disp.plot(ax=ax, xticks_rotation="vertical", colorbar=True)
+        plt.tight_layout()
+        fig.savefig(os.path.join(outfolder, f"cm_{k}.png"), transparent=False)
 
 
 if __name__ == "__main__":
@@ -138,13 +201,13 @@ if __name__ == "__main__":
     texts, labels = process_eval_data(eval_data, argm)
 
     print(
-        f"Evaluting argmatcher with:\n\t \
-        n_neighbors: {args.n_neighbors}\n\t \
-        threshold: {args.threshold}\n\t \
+        f"Evaluting argmatcher with:\n \
+        n_neighbors: {args.n_neighbors}\n \
+        threshold: {args.threshold}\n \
         certain_threshold: {args.certain_threshold}"
     )
 
-    bal_acc, pred_labels, encoded_labels = evaluate_model(
+    bal_acc, pred_labels_enc, true_labels_enc = evaluate_model(
         argm,
         texts,
         labels,
@@ -155,3 +218,10 @@ if __name__ == "__main__":
     print(f"Balanced accuracy is: {bal_acc}")
 
     os.makedirs("./eval_logs/", exist_ok=True)
+
+    ename = os.path.splitext(os.path.basename(eval_data))[0]
+    ctime = datetime.now().strftime("%H-%M-%d-%m-%Y")
+    log_folder = os.path.join("./eval_logs/", f"{ename}_{ctime}")
+    os.makedirs(log_folder, exist_ok=True)
+
+    log_eval_results(log_folder, argm, texts, pred_labels_enc, true_labels_enc)

--- a/redditbot.py
+++ b/redditbot.py
@@ -130,7 +130,12 @@ class MentionsBot:
             link = r["link"]
 
             if arg not in args:
-                args[arg] = {"passage": passage, "quotes": [inp], "sim": sim, "link": link}
+                args[arg] = {
+                    "passage": passage,
+                    "quotes": [inp],
+                    "sim": sim,
+                    "link": link,
+                }
             else:
                 args[arg]["quotes"].append(inp)
                 if args[arg]["sim"] < sim:
@@ -216,7 +221,9 @@ class MentionsBot:
                         if isinstance(parent, Comment):
                             input_text = self.remove_usernames(parent.body)
                         elif isinstance(parent, Submission):
-                            input_text = self.remove_usernames(".".join([parent.title, parent.selftext]))
+                            input_text = self.remove_usernames(
+                                ".".join([parent.title, parent.selftext])
+                            )
                         else:
                             input_text = None
                     except:
@@ -285,7 +292,9 @@ class MentionsBot:
                             try:
                                 reply = parent.reply(response)
                                 print(response)
-                                reply_info["outcome"] = "Replied with matched argument(s)"
+                                reply_info[
+                                    "outcome"
+                                ] = "Replied with matched argument(s)"
                                 reply_info["reply_id"] = reply.id
                             except prawcore.exceptions.Forbidden:
                                 reply_info[


### PR DESCRIPTION
# Features Added
- The eval pipeline now outputs the following into an eval directory, given an input test csv:
    - precision, recall, and un-normalized confusion matrix figures 
    - a csv with each example, predicted label, true label
- Some other small changes
    - Improved documentation on `key_label_map` in the `ArgMatcher` class
    - Examples in the test csv which are found in the training set are excluded

Below is the example output of the model using [this test csv](https://gist.github.com/cvqluu/df0323b68f17bc255d546d4c6865e9fd) and the following settings:
- `threshold = 0.5`
- `certain_threshold = 0.9`
- `n_neighbors = 3`

### Un-normalized
<img src="https://user-images.githubusercontent.com/32367480/161807056-ed1a9610-aaba-4369-a47a-39d1ad80f729.png" width="600"/>

## Normalized by pred class(diagonal is recall)
<img src="https://user-images.githubusercontent.com/32367480/161807067-e8b53ad2-f894-4b31-b2c1-1366fdea8cff.png" width="600"/>

## Normalized by true class (diagonal is precision)
<img src="https://user-images.githubusercontent.com/32367480/161807074-6b2f9665-cf0d-4a51-b08b-fad4c16f3674.png" width="600"/>

# TODOs:
- ~~Make a small csv with all "single number" metrics all in one~~
    - ~~Balanced acc~~
    - ~~Average precision/recall~~
- Make a test set that appropriately tests the bot behaviour
    - Include more `_na_` examples
- ~~[Bug] Need to investigate why certain examples are classified correctly in test mode and reddit bot but not in `eval.py` output~~